### PR TITLE
Display counts 0000-9999 and morse code running simultaneously only talking with my drivers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,17 +21,17 @@ include_directories(
 
 set(SRC_FILES
     app/main.c
-    puzzles/source/morse.c
     drivers/source/timer.c
     drivers/source/adc.c
     drivers/source/spi.c
     drivers/source/gpio.c
+    drivers/source/display_7seg.c
+    puzzles/source/morse.c
+    puzzles/source/pot_to_digits.c
 )
 
-# 1. Bygg elf-filen
 add_executable(main.elf ${SRC_FILES})
 
-# 2. Berätta för CMake exakt HUR filen main.hex skapas från main.elf
 add_custom_command(
     OUTPUT main.hex
     COMMAND ${CMAKE_OBJCOPY} -j .text -j .data -O ihex main.elf main.hex
@@ -39,7 +39,6 @@ add_custom_command(
     COMMENT "Generating main.hex from main.elf"
 )
 
-# 3. Flashtarget som nu förstår att main.hex är en fil som genereras ovan
 add_custom_target(flash
     COMMAND avrdude -p atmega328p -c arduino -P /dev/ttyACM0 -b 115200 -U flash:w:main.hex:i
     DEPENDS main.hex

--- a/app/main.c
+++ b/app/main.c
@@ -1,20 +1,70 @@
+#define F_CPU 16000000UL
 #include <avr/io.h>
-#include <avr/interrupt.h>
-#include <stddef.h>
-
-#include "gpio.h"
+#include <util/delay.h>
+#include "spi.h"
 #include "timer.h"
-#include "morse.h"
+
+const uint8_t SEGMENTS[] = {
+    0x3F, // 0
+    0x06, // 1
+    0x5B, // 2
+    0x4F, // 3
+    0x66, // 4
+    0x6D, // 5
+    0x7D, // 6
+    0x07, // 7
+    0x7F, // 8
+    0x6F  // 9
+};
+
+const uint8_t DIGITS[] = {
+    0xFE,
+    0xFD,
+    0xFB,
+    0xF7
+};
+
+volatile uint8_t display_buffer[4] = {0x3F, 0x3F, 0x3F, 0x3F};
+
+uint16_t counter = 0;
+
+void display_multiplex_callback(void) {
+    static uint8_t current_digit = 0;
+
+    
+    spi_write(DIGITS[current_digit]);
+    spi_write(display_buffer[current_digit]);
+    spi_latch();
+
+    current_digit++;
+    if (current_digit >= 4) {
+        current_digit = 0;
+    }
+}
+
+void counter_increment_callback(void) {
+    counter++;
+    if (counter > 9999) {
+        counter = 0;
+    }
+
+    display_buffer[0] = SEGMENTS[(counter / 1000) % 10]; 
+    display_buffer[1] = SEGMENTS[(counter / 100) % 10];
+    display_buffer[2] = SEGMENTS[(counter / 10) % 10];
+    display_buffer[3] = SEGMENTS[counter % 10];
+}
+
 
 int main(void) {
-    
-    timer_init();
-    
-    gpio_t* morse_led = gpio_new(6, GPIO_DIRECTION_OUTPUT, NULL);
-        
-    morse_start(morse_led);
 
-    sei(); 
+    spi_init();
+    timer_init(); 
+
+    struct timer *display_timer = timer_new(2, display_multiplex_callback);
+    struct timer *counter_timer = timer_new(500, counter_increment_callback);
+
+    timer_start(display_timer);
+    timer_start(counter_timer);
 
     while (1) {
         
@@ -22,6 +72,5 @@ int main(void) {
 
     }
 
-    gpio_delete(&morse_led);
     return 0;
 }

--- a/app/main.c
+++ b/app/main.c
@@ -1,82 +1,41 @@
 #define F_CPU 16000000UL
-#include <avr/io.h>
 #include <avr/interrupt.h>
-#include <util/delay.h>
 #include <stddef.h>
+#include <stdbool.h>
 
-#include "spi.h"
 #include "timer.h"
 #include "gpio.h"
 #include "morse.h"
-
-const uint8_t SEGMENTS[] = {
-    0x3F, // 0
-    0x06, // 1
-    0x5B, // 2
-    0x4F, // 3
-    0x66, // 4
-    0x6D, // 5
-    0x7D, // 6
-    0x07, // 7
-    0x7F, // 8
-    0x6F  // 9
-};
-
-const uint8_t DIGITS[] = {
-    0xFE, // Siffra 1
-    0xFD, // Siffra 2
-    0xFB, // Siffra 3
-    0xF7  // Siffra 4
-};
-
-volatile uint8_t display_buffer[4] = {0x3F, 0x3F, 0x3F, 0x3F};
-uint16_t counter = 0;
-
-void display_multiplex_callback(void) {
-    static uint8_t current_digit = 0;
-
-    spi_write(DIGITS[current_digit]);
-    spi_write(display_buffer[current_digit]);
-    spi_latch();
-
-    current_digit++;
-    if (current_digit >= 4) {
-        current_digit = 0;
-    }
-}
-
-void counter_increment_callback(void) {
-    counter++;
-    if (counter > 9999) {
-        counter = 0;
-    }
-
-    display_buffer[0] = SEGMENTS[(counter / 1000) % 10]; 
-    display_buffer[1] = SEGMENTS[(counter / 100) % 10];
-    display_buffer[2] = SEGMENTS[(counter / 10) % 10];
-    display_buffer[3] = SEGMENTS[counter % 10];
-}
+#include "pot_to_digits.h"
 
 int main(void) {
-    
-    spi_init();
+
     timer_init(); 
 
     gpio_t* morse_led = gpio_new(6, GPIO_DIRECTION_OUTPUT, NULL);
+    gpio_t* puzzle_solved_led = gpio_new(7, GPIO_DIRECTION_OUTPUT, NULL);
 
-    struct timer *display_timer = timer_new(2, display_multiplex_callback);
-    struct timer *counter_timer = timer_new(500, counter_increment_callback);
+    pot_to_digits_init();
+    pot_to_digits_start();
 
-    timer_start(display_timer);
-    timer_start(counter_timer);
     morse_start(morse_led);
 
     sei(); 
 
     while (1) {
+
         timer_handler();
+
+        
+        if (pot_to_digits_is_solved()) {
+            
+            pot_to_digits_stop(); 
+            
+            gpio_write(puzzle_solved_led, true); 
+        }
     }
 
     gpio_delete(&morse_led);
+    gpio_delete(&puzzle_solved_led);
     return 0;
 }

--- a/app/main.c
+++ b/app/main.c
@@ -1,8 +1,13 @@
 #define F_CPU 16000000UL
 #include <avr/io.h>
+#include <avr/interrupt.h>
 #include <util/delay.h>
+#include <stddef.h>
+
 #include "spi.h"
 #include "timer.h"
+#include "gpio.h"
+#include "morse.h"
 
 const uint8_t SEGMENTS[] = {
     0x3F, // 0
@@ -18,20 +23,18 @@ const uint8_t SEGMENTS[] = {
 };
 
 const uint8_t DIGITS[] = {
-    0xFE,
-    0xFD,
-    0xFB,
-    0xF7
+    0xFE, // Siffra 1
+    0xFD, // Siffra 2
+    0xFB, // Siffra 3
+    0xF7  // Siffra 4
 };
 
 volatile uint8_t display_buffer[4] = {0x3F, 0x3F, 0x3F, 0x3F};
-
 uint16_t counter = 0;
 
 void display_multiplex_callback(void) {
     static uint8_t current_digit = 0;
 
-    
     spi_write(DIGITS[current_digit]);
     spi_write(display_buffer[current_digit]);
     spi_latch();
@@ -54,23 +57,26 @@ void counter_increment_callback(void) {
     display_buffer[3] = SEGMENTS[counter % 10];
 }
 
-
 int main(void) {
-
+    
     spi_init();
     timer_init(); 
+
+    gpio_t* morse_led = gpio_new(6, GPIO_DIRECTION_OUTPUT, NULL);
 
     struct timer *display_timer = timer_new(2, display_multiplex_callback);
     struct timer *counter_timer = timer_new(500, counter_increment_callback);
 
     timer_start(display_timer);
     timer_start(counter_timer);
+    morse_start(morse_led);
+
+    sei(); 
 
     while (1) {
-        
         timer_handler();
-
     }
 
+    gpio_delete(&morse_led);
     return 0;
 }

--- a/drivers/source/display_7seg.c
+++ b/drivers/source/display_7seg.c
@@ -1,5 +1,5 @@
 /**
- * @file display.c
+ * @file display_7seg.c
  * @brief Driver implementation for 7-segment display using SPI and shift registers.
  */
 
@@ -8,86 +8,51 @@
 #include <avr/io.h>
 
 /**
- * @brief Look-up Table for 7-segment display (Common Cathode/Anode dependent).
- * * Mapping based on: Q0=A, Q1=B, Q2=C, Q3=D, Q4=E, Q5=F, Q6=G.
+ * @brief Look-up Table for 7-segment display.
  */
 static const uint8_t segment_map[] = {
-    0x3F, // 0: 0011 1111
-    0x06, // 1: 0000 0110
-    0x5B, // 2: 0101 1011
-    0x4F, // 3: 0100 1111
-    0x66, // 4: 0110 0110
-    0x6D, // 5: 0110 1101
-    0x7D, // 6: 0111 1101
-    0x07, // 7: 0000 0111
-    0x7F, // 8: 0111 1111
-    0x6F  // 9: 0110 1111
+    0x3F, // 0
+    0x06, // 1
+    0x5B, // 2
+    0x4F, // 3
+    0x66, // 4
+    0x6D, // 5
+    0x7D, // 6
+    0x07, // 7
+    0x7F, // 8
+    0x6F  // 9
 };
 
-/**
- * @brief Digit selection map to activate specific display positions.
- * * Defines which digit (1-4) receives power or ground via the first shift register.
- */
 static const uint8_t digit_map[] = {
-    0x01, // Siffra 1 (left)
-    0x02, // Siffra 2
-    0x04, // Siffra 3
-    0x08  // Siffra 4 (right)
+    0xFE, // 1
+    0xFD, // 2
+    0xFB, // 3
+    0xF7 //  4
 };
-
-/**
- * @brief Initializes the display system.
- * * Sets up SPI hardware and ensures the display is cleared at startup.
- */
 
 void display_init(void) {
-    spi_init(); // Initiera SPI-hårdvaran
+    spi_init();
     display_clear();
 }
 
-/**
- * @brief Displays a single digit on the first position.
- * @param number The digit to display (0-9).
- */
-
-void display_show_number(uint8_t number) {
-    if (number > 9) return;
-
-    // Vi hämtar mönstret för siffran
-    uint8_t segments = segment_map[number];
-    
-    // send to shift registers
-    spi_write(segments);      // Skickas till Chip 2 
-    spi_write(digit_map[0]);  // Skickas till Chip 1 
-    
-    spi_latch(); // outputs
-}
-
-/**
- * @brief Clears the entire display.
- * * Turns off all segments and deactivates all digit positions.
- */
-
 void display_clear(void) {
-    spi_write(0xFF); // turn off all segments
-    spi_write(0x00); // deactive all numbers
+    
+    spi_write(0xFF); 
+    spi_write(0x00);
     spi_latch();
 }
 
-/**
- * @brief Writes a specific number to a specific display position.
- * * Used for multiplexing multiple digits across the 4-digit display.
- * @param number The digit to display (0-9).
- * @param pos The position to use (0=Leftmost, 3=Rightmost).
- */
+void display_show_number(uint8_t number) {
+    
+    display_write_pos(number, 0);
+}
 
 void display_write_pos(uint8_t number, uint8_t pos) {
     if (number > 9 || pos > 3) return;
 
-    uint8_t segments = segment_map[number];
-    uint8_t digit = digit_map[pos];
+    spi_write(digit_map[pos]);
 
-    spi_write(segments); // Chip 2 (Segment)
-    spi_write(digit);    // Chip 1 (Position)
+    spi_write(segment_map[number]);
+
     spi_latch();
 }

--- a/puzzles/include/pot_to_digits.h
+++ b/puzzles/include/pot_to_digits.h
@@ -1,0 +1,18 @@
+/**
+ * @file pot_to_digits.h
+ * @author Oliver Edman <o.edman@icloud.com>
+ * @brief Logic for pot to digits puzzle.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+void pot_to_digits_init(void);
+
+void pot_to_digits_start(void);
+
+void pot_to_digits_stop(void);
+
+// Return True if puzzle is solved, false otherwise used for LED that indicate if puzzle is solved or not. 
+bool pot_to_digits_is_solved(void);

--- a/puzzles/source/pot_to_digits.c
+++ b/puzzles/source/pot_to_digits.c
@@ -1,0 +1,51 @@
+#include "pot_to_digits.h"
+#include "display_7seg.h"
+#include "adc.h"
+#include "timer.h"
+#include <stddef.h>
+
+static volatile uint8_t current_digits[4] = {0, 0, 0, 0};
+static bool is_puzzle_solved = false;
+static uint16_t counter = 0; 
+static struct timer* display_timer = NULL;
+static struct timer* counter_timer = NULL;
+
+static void display_multiplex_callback(void) {
+    static uint8_t current_digit_idx = 0;
+    display_write_pos(current_digits[current_digit_idx], current_digit_idx);
+    current_digit_idx = (current_digit_idx + 1) % 4;
+}
+
+static void counter_increment_callback(void) {
+    counter++;
+    if (counter > 9999) {
+        counter = 0;
+    }
+
+    current_digits[0] = (counter / 1000) % 10;
+    current_digits[1] = (counter / 100) % 10;
+    current_digits[2] = (counter / 10) % 10;
+    current_digits[3] = counter % 10;
+}
+
+void pot_to_digits_init(void) {
+    display_init(); 
+    display_timer = timer_new(2, display_multiplex_callback);
+    counter_timer = timer_new(500, counter_increment_callback);
+}
+
+void pot_to_digits_start(void) {
+    timer_start(display_timer);
+    timer_start(counter_timer);
+    counter = 0;
+    is_puzzle_solved = false;
+}
+
+void pot_to_digits_stop(void) {
+    timer_stop(display_timer);
+    timer_stop(counter_timer);
+}
+
+bool pot_to_digits_is_solved(void) {
+    return is_puzzle_solved;
+}


### PR DESCRIPTION
Successfully integrated two puzzle concepts running concurrently without blocking the CPU only using my drivers.

### Key Changes
* Created a temporary `pot_to_digits` puzzle module that runs a 500 ms counter and a 2 ms display multiplexer.
* Integrated the `display_7seg` driver with the underlying hardware `spi` driver.
* Cleaned `main.c` from "magic numbers" and low level register manipulation.
* Fixed CMake configuration to properly compile and link the new puzzle module.

### Verification
* Verified that Timer0 handles both the Morse code module and the 7-segment multiplexing smoothly without any problems.